### PR TITLE
add chainId to sent transaction

### DIFF
--- a/app/components/Crossmint.tsx
+++ b/app/components/Crossmint.tsx
@@ -138,6 +138,7 @@ const Crossmint: React.FC<CrossmintProps> = ({
                             to: transaction.to as `0x${string}`,
                             value: BigInt(transaction.value.toString()),
                             data: transaction.data as `0x${string}`,
+                            chainId: transaction.chainId,
                           });
 
                           return result;


### PR DESCRIPTION
This prevents sending the transaction to the wrong chain and also replay attacks.

Tested by performing a purchase. Debugging logs show the field being properly added.
![image](https://github.com/Crossmint/embedded-crosschain-demo/assets/146016735/04861893-45f2-4458-8728-4e3b4ecb2d82)
